### PR TITLE
Fix the build by removing the constructor with one argument from the …

### DIFF
--- a/Source/Core/Chill.Net45/Properties/AssemblyInfo.cs
+++ b/Source/Core/Chill.Net45/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("2.1.0.1")]
 [assembly: AssemblyVersion("2.1.0.1")]
 [assembly: AssemblyFileVersion("2.1.0.1")]
+
+[assembly: InternalsVisibleTo("Chill.Net45.Tests")] 

--- a/Source/Core/Chill.Net45/TinyIocChillContainer.cs
+++ b/Source/Core/Chill.Net45/TinyIocChillContainer.cs
@@ -13,11 +13,6 @@ namespace Chill
             _container = new TinyIoCContainer();
         }
 
-        public TinyIocChillContainer(TinyIoCContainer container)
-        {
-            _container = container;
-        }
-
         public void Dispose()
         {
             _container.Dispose();


### PR DESCRIPTION
…TinyIocChillContainer .

The build was broken after the pull request #61.